### PR TITLE
Refactor damage recording in character classes

### DIFF
--- a/hsr_simulation/character.py
+++ b/hsr_simulation/character.py
@@ -313,13 +313,9 @@ class Character:
         return current_char_action_value * action_forward_percent
 
     def calculate_action_value(self, speed: float) -> float:
-        """
-        Calculate action value
-        :param speed: Character speed
-        :return: Action value
-        """
-        main_logger.info(f'Calculating action value...')
-        char_action_value = 10000 / speed
+        """Calculate action value based on speed"""
+        main_logger.info('Calculating action value...')
+        char_action_value = self.ACTION_VALUE_BASE / speed
         self.char_action_value = char_action_value
         return char_action_value
 

--- a/hsr_simulation/nihility/acheron.py
+++ b/hsr_simulation/nihility/acheron.py
@@ -87,8 +87,7 @@ class Acheron(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=1, slash_dream=0)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Basic ATK')
+        self._record_damage(dmg, 'Basic ATK')
 
     def _use_skill(self) -> None:
         """
@@ -102,8 +101,7 @@ class Acheron(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=-1, slash_dream=1)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Skill')
+        self._record_damage(dmg, 'Skill')
 
         self.crimson_knot += 1
         self.crimson_knot = min(9, self.crimson_knot)
@@ -168,8 +166,7 @@ class Acheron(Character):
         final_total_dmg = float(sum(total_dmg))
         final_dmg = min(final_total_dmg, max_dmg)
 
-        self.data['DMG'].append(final_dmg)
-        self.data['DMG_Type'].append('Ultimate')
+        self._record_damage(final_dmg, 'Ultimate')
 
         # A6 Trace DMG
         for _ in range(6):
@@ -177,8 +174,7 @@ class Acheron(Character):
                                                     dmg_multipliers=[self.a4_dmg_multiplier,
                                                                      self.a6_dmg_multiplier],
                                                     res_multipliers=res_pen)
-            self.data['DMG'].append(additional_dmg)
-            self.data['DMG_Type'].append('Ultimate')
+            self._record_damage(additional_dmg, 'Ultimate')
 
     def _remove_crimson_knot(self, remove_amount: int = 3) -> tuple[float, int]:
         """

--- a/hsr_simulation/nihility/black_swan.py
+++ b/hsr_simulation/nihility/black_swan.py
@@ -54,7 +54,7 @@ class BlackSwan(Character):
 
         # simulate A4 Trace
         if self.battle_start:
-            main_logger.debug(f'Battle starts')
+            main_logger.debug('Battle starts')
             self.battle_start = False
             self._apply_arcana()
 
@@ -71,7 +71,7 @@ class BlackSwan(Character):
             self.current_ult_energy = 5
 
         # simulate A4 Trace br randomizing ally's DoT attack
-        main_logger.debug(f'Randomizing ally DoT attack...')
+        main_logger.debug('Randomizing ally DoT attack...')
         if random.random() < 0.5:
             self._apply_arcana()
 
@@ -100,8 +100,7 @@ class BlackSwan(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=1, ult_energy=20)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Basic ATK')
+        self._record_damage(dmg, 'Basic ATK')
 
         # generate Arcana stack
         self._apply_arcana()
@@ -127,8 +126,7 @@ class BlackSwan(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=-1, ult_energy=30)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Skill')
+        self._record_damage(dmg, 'Skill')
 
         # generate Arcana
         self.arcana += 1
@@ -149,8 +147,7 @@ class BlackSwan(Character):
             dmg = self._calculate_damage(skill_multiplier=1.2, break_amount=30,
                                          dmg_multipliers=[self.a6_dmg_multiplier])
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Ultimate')
+        self._record_damage(dmg, 'Ultimate')
 
         self.epiphany = 2
 
@@ -193,9 +190,8 @@ class BlackSwan(Character):
                                              dmg_multipliers=dmg_multiplier,
                                              can_crit=False)
 
-            self.data['DMG'].append(dmg)
-            self.data['DMG_Type'].append('DoT')
+            self._record_damage(dmg, 'DoT')
 
             if self.epiphany <= 0:
-                main_logger.debug(f'Epiphany stack is zero or less. Reset Arcana stack to 1.')
+                main_logger.debug('Epiphany stack is zero or less. Reset Arcana stack to 1.')
                 self.arcana = 1

--- a/hsr_simulation/nihility/fugue.py
+++ b/hsr_simulation/nihility/fugue.py
@@ -167,8 +167,7 @@ class Fugue(Character):
         )
         self._update_skill_point_and_ult_energy(skill_points=1, ult_energy=20)
 
-        self.data["DMG"].append(dmg)
-        self.data["DMG_Type"].append("Basic ATK")
+        self._record_damage(dmg, "Basic ATK")
 
     def _use_enhance_basic_atk(self) -> None:
         """
@@ -189,8 +188,7 @@ class Fugue(Character):
         )
         self._update_skill_point_and_ult_energy(skill_points=1, ult_energy=20)
 
-        self.data["DMG"].append(dmg)
-        self.data["DMG_Type"].append("Enhanced Basic ATK")
+        self._record_damage(dmg, "Enhanced Basic ATK")
 
     def _use_skill(self) -> None:
         """
@@ -210,8 +208,7 @@ class Fugue(Character):
     
         self.foxian_player = 3  # Reset Foxian Player duration
 
-        self.data["DMG"].append(dmg)
-        self.data["DMG_Type"].append("Skill")
+        self._record_damage(dmg, "Skill")
 
     def _use_ult(self) -> None:
         """
@@ -229,8 +226,7 @@ class Fugue(Character):
             def_reduction_multiplier=[def_reduce]
         )
 
-        self.data["DMG"].append(dmg)
-        self.data["DMG_Type"].append("Ultimate")
+        self._record_damage(dmg, "Ultimate")
 
     def _simulate_a4_trace(self) -> None:
         """

--- a/hsr_simulation/nihility/guinanfei.py
+++ b/hsr_simulation/nihility/guinanfei.py
@@ -47,7 +47,7 @@ class Guinanfei(Character):
         """
         main_logger.info(f'{self.__class__.__name__} is taking actions...')
 
-        main_logger.info(f'Simulate enemy turn')
+        main_logger.info('Simulate enemy turn')
         # simulate enemy turn
         self._simulate_enemy_weakness_broken()
 
@@ -61,7 +61,7 @@ class Guinanfei(Character):
                     self.firekiss = []
 
         if self.battle_start:
-            main_logger.debug(f'Battle Start. Apply A4 trace effect')
+            main_logger.debug('Battle Start. Apply A4 trace effect')
             self.battle_start = False
             self.speed *= 1.25
         else:
@@ -98,12 +98,11 @@ class Guinanfei(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=1, ult_energy=20)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Basic ATK')
+        self._record_damage(dmg, 'Basic ATK')
 
         # simulate A2 Trace
         if random.random() < 0.8:
-            main_logger.debug(f'Apply Burn from A2 trace effect')
+            main_logger.debug('Apply Burn from A2 trace effect')
             self.burn = 2
 
     def _use_skill(self) -> None:
@@ -122,8 +121,7 @@ class Guinanfei(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=-1, ult_energy=30)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Skill')
+        self._record_damage(dmg, 'Skill')
 
         self.burn = 2
 
@@ -142,8 +140,7 @@ class Guinanfei(Character):
             dmg = self._calculate_damage(skill_multiplier=1.2, break_amount=20,
                                          dmg_multipliers=[self.a6_dmg_multiplier])
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Ultimate')
+        self._record_damage(dmg, 'Ultimate')
 
         if self.burn > 0:
             self._apply_dot(ult_trigger=True)
@@ -167,8 +164,7 @@ class Guinanfei(Character):
         if ult_trigger:
             dmg *= 0.92
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('DoT')
+        self._record_damage(dmg, 'DoT')
 
         if len(self.firekiss) < 3:
             self.firekiss.append(3)

--- a/hsr_simulation/nihility/jiaoqiu.py
+++ b/hsr_simulation/nihility/jiaoqiu.py
@@ -96,8 +96,7 @@ class Jiaoqiu(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=1, ult_energy=20)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Basic ATK')
+        self._record_damage(dmg, 'Enhanced Basic ATK')
 
         self._inflict_ashen_roast()
 
@@ -112,8 +111,7 @@ class Jiaoqiu(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=-1, ult_energy=30)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Skill')
+        self._record_damage(dmg, 'Skill')
 
         self._inflict_ashen_roast()
 
@@ -128,8 +126,7 @@ class Jiaoqiu(Character):
             dmg_multiplier += 0.15
         dmg = self._calculate_damage(skill_multiplier=1, break_amount=20, dmg_multipliers=[dmg_multiplier])
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Ultimate')
+        self._record_damage(dmg, 'Ultimate')
 
         self.zone = 3
 
@@ -165,8 +162,7 @@ class Jiaoqiu(Character):
             dmg = self._calculate_damage(skill_multiplier=1.8, break_amount=0, dmg_multipliers=[dmg_multiplier],
                                          can_crit=False)
 
-            self.data['DMG'].append(dmg)
-            self.data['DMG_Type'].append('DoT')
+            self._record_damage(dmg, 'DoT')
 
     def _simulate_enemy_turn(self) -> None:
         """

--- a/hsr_simulation/nihility/kafka.py
+++ b/hsr_simulation/nihility/kafka.py
@@ -76,8 +76,7 @@ class Kafka(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=1, ult_energy=20)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Basic ATK')
+        self._record_damage(dmg, 'Basic ATK')
 
     def _use_skill(self) -> None:
         """
@@ -87,8 +86,7 @@ class Kafka(Character):
         main_logger.info("Using skill...")
         dmg = self._calculate_damage(skill_multiplier=1.6, break_amount=20)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Skill')
+        self._record_damage(dmg, 'Skill')
 
         self._update_skill_point_and_ult_energy(skill_points=-1, ult_energy=30)
 
@@ -106,8 +104,7 @@ class Kafka(Character):
         main_logger.info('Using ultimate...')
         dmg = self._calculate_damage(skill_multiplier=0.8, break_amount=20)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Ultimate')
+        self._record_damage(dmg, 'Ultimate')
 
         self.shock = 2
 
@@ -124,8 +121,7 @@ class Kafka(Character):
         self.shock = 2
         self.talent_cooldown = True
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Talent')
+        self._record_damage(dmg, 'Talent')
 
     def _use_shock(self, skill_trigger: bool = False) -> float:
         """
@@ -140,8 +136,7 @@ class Kafka(Character):
         else:
             dmg = self._calculate_damage(skill_multiplier=2.9, break_amount=0, can_crit=False)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('DoT')
+        self._record_damage(dmg, 'DoT')
 
         return dmg
 

--- a/hsr_simulation/nihility/luka.py
+++ b/hsr_simulation/nihility/luka.py
@@ -93,8 +93,7 @@ class Luka(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=1, ult_energy=20)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Basic ATK')
+        self._record_damage(dmg, 'Basic ATK')
 
         self._get_fighting_will(fighting_will_amount=1)
 
@@ -108,8 +107,7 @@ class Luka(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=-1, ult_energy=30)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Skill')
+        self._record_damage(dmg, 'Skill')
 
         self.bleed = 3
         self._get_fighting_will(fighting_will_amount=1)
@@ -126,8 +124,7 @@ class Luka(Character):
         else:
             dmg = self._calculate_damage(skill_multiplier=3.3, break_amount=30)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Ultimate')
+        self._record_damage(dmg, 'Ultimate')
 
         self._get_fighting_will(fighting_will_amount=2)
         self.ult_buff = 3
@@ -149,8 +146,7 @@ class Luka(Character):
         if talent_trigger:
             dmg *= 0.85
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('DoT')
+        self._record_damage(dmg, 'DoT')
 
     def _use_enhanced_basic_atk(self) -> None:
         """
@@ -176,15 +172,13 @@ class Luka(Character):
                 additional_dmg = 0
             dmg += additional_dmg
 
-            self.data['DMG'].append(dmg)
-            self.data['DMG_Type'].append('Enhanced Basic ATK')
+            self._record_damage(dmg, 'Enhanced Basic ATK')
 
         # simulate Rising Uppercut
         dmg = self._calculate_damage(skill_multiplier=0.8, break_amount=20,
                                      dmg_multipliers=dmg_multiplier)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Enhanced Basic ATK')
+        self._record_damage(dmg, 'Enhanced Basic ATK')
 
         self._update_skill_point_and_ult_energy(skill_points=0, ult_energy=20)
 

--- a/hsr_simulation/nihility/pela.py
+++ b/hsr_simulation/nihility/pela.py
@@ -86,8 +86,7 @@ class Pela(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=1, ult_energy=20)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Basic ATK')
+        self._record_damage(dmg, 'Basic ATK')
 
     def _use_skill(self) -> None:
         """
@@ -109,8 +108,7 @@ class Pela(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=-1, ult_energy=30)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Skill')
+        self._record_damage(dmg, 'Skill')
 
         # A6 trace
         if self.enemy_has_buff:
@@ -136,7 +134,6 @@ class Pela(Character):
 
         dmg = self._calculate_damage(skill_multiplier=1, break_amount=20, dmg_multipliers=[dmg_multipler])
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Ultimate')
+        self._record_damage(dmg, 'Ultimate')
 
         self.exposed = 2

--- a/hsr_simulation/nihility/sampo.py
+++ b/hsr_simulation/nihility/sampo.py
@@ -82,8 +82,7 @@ class Sampo(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=1, ult_energy=20)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Basic ATK')
+        self._record_damage(dmg, 'Basic ATK')
 
         self._inflict_wind_shear()
 
@@ -100,8 +99,7 @@ class Sampo(Character):
 
             self._update_skill_point_and_ult_energy(skill_points=0, ult_energy=6)
 
-            self.data['DMG'].append(dmg)
-            self.data['DMG_Type'].append('Skill')
+            self._record_damage(dmg, 'Skill')
 
         self._inflict_wind_shear()
 
@@ -113,8 +111,7 @@ class Sampo(Character):
         main_logger.info(f'{self.__class__.__name__} is using ultimate...')
         dmg = self._calculate_damage(skill_multiplier=1.6, break_amount=20)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Ultimate')
+        self._record_damage(dmg, 'Ultimate')
 
         self.ult_buff = 2
 
@@ -153,5 +150,4 @@ class Sampo(Character):
             dmg = self._calculate_damage(skill_multiplier=0.52, break_amount=0,
                                          dot_dmg_multipliers=dot_dmg_multiplier, can_crit=False)
 
-            self.data['DMG'].append(dmg)
-            self.data['DMG_Type'].append('DoT')
+            self._record_damage(dmg, 'DoT')

--- a/hsr_simulation/nihility/silver_wolf.py
+++ b/hsr_simulation/nihility/silver_wolf.py
@@ -100,8 +100,7 @@ class SilverWolf(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=1, ult_energy=20)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Basic ATK')
+        self._record_damage(dmg, 'Basic ATK')
 
     def _use_skill(self) -> None:
         """
@@ -143,8 +142,7 @@ class SilverWolf(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=-1, ult_energy=30)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Skill')
+        self._record_damage(dmg, 'Skill')
 
     def _use_ult(self) -> None:
         """
@@ -170,8 +168,7 @@ class SilverWolf(Character):
                                      def_reduction_multiplier=def_reduction_multiplier,
                                      res_multipliers=res_reduction_multiplier)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Ultimate')
+        self._record_damage(dmg, 'Ultimate')
 
     def _apply_bugs(self, a2_trace_trigger: bool = False) -> None:
         """

--- a/hsr_simulation/nihility/welt.py
+++ b/hsr_simulation/nihility/welt.py
@@ -77,8 +77,7 @@ class Welt(Character):
 
         self._update_skill_point_and_ult_energy(skill_points=1, ult_energy=20)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Basic ATK')
+        self._record_damage(dmg, 'Basic ATK')
 
     def _use_skill(self) -> None:
         """
@@ -93,8 +92,7 @@ class Welt(Character):
                                          dmg_multipliers=dmg_multiplier)
             self._update_skill_point_and_ult_energy(skill_points=-1, ult_energy=30)
 
-            self.data['DMG'].append(dmg)
-            self.data['DMG_Type'].append('Skill')
+            self._record_damage(dmg, 'Skill')
 
             # simulate Talent
             if random.random() < 0.75:
@@ -111,8 +109,7 @@ class Welt(Character):
         dmg = self._calculate_damage(skill_multiplier=1.5, break_amount=20,
                                      dmg_multipliers=dmg_multiplier)
 
-        self.data['DMG'].append(dmg)
-        self.data['DMG_Type'].append('Ultimate')
+        self._record_damage(dmg, 'Ultimate')
 
         self._apply_talent_dmg()
 
@@ -138,8 +135,7 @@ class Welt(Character):
             dmg_multiplier = self._apply_a2_trace()
             dmg = self._calculate_damage(skill_multiplier=0.6, break_amount=0,
                                          dmg_multipliers=dmg_multiplier)
-            self.data['DMG'].append(dmg)
-            self.data['DMG_Type'].append('Talent')
+            self._record_damage(dmg, 'Talent')
 
     def _calculate_damage(
             self,


### PR DESCRIPTION
- Replaced direct damage data appending with a centralized `_record_damage` method across multiple character classes, including `Acheron`, `BlackSwan`, `Fugue`, `Guinanfei`, `Jiaoqiu`, `Kafka`, `Luka`, `Pela`, `Sampo`, `SilverWolf`, and `Welt`.
- Updated logging statements for consistency by removing unnecessary f-strings.
- Improved code maintainability and readability by standardizing damage recording logic.