### PR TITLE
Fix Remembrance Trailblazer skill usage logic and remove redundant action call

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,12 +80,14 @@ You can customize the simulation using the following command-line arguments:
   If not specified, all paths will be simulated.
 
 - `--sim-count`: Number of battle simulations to run (default: 1000)
+  > Does not affect the Harmony path.
 
   ```bash
   python main.py --sim-count 500  # Run 500 simulations
   ```
 
 - `--max-cycles`: Maximum number of cycles to simulate per battle (default: 10)
+  > Does not affect the Harmony path.
 
   ```bash
   python main.py --max-cycles 15  # Run for 15 cycles

--- a/hsr_simulation/remembrance/remembrance_trailblazer.py
+++ b/hsr_simulation/remembrance/remembrance_trailblazer.py
@@ -70,7 +70,7 @@ class RemembranceTrailblazer(Character):
             self.battle_start = False
 
         # Trailblazer's turn
-        if self.skill_points > 0 and self.mem is not None:
+        if self.skill_points > 0 and self.mem is None:
             self._use_skill()
         else:
             self._use_basic_atk()
@@ -138,8 +138,6 @@ class RemembranceTrailblazer(Character):
 
         if self._mem_can_use_ult():
             self._apply_mem_true_dmg_buff()
-            
-        self.take_action()
 
     def _use_ult(self) -> None:
         """Simulate ultimate damage."""


### PR DESCRIPTION
- Correct skill point usage condition in take_action method
- Remove unnecessary self.take_action() call in _use_ult method
- Improve character action flow in Remembrance Trailblazer class